### PR TITLE
#1 - Fix warning for import scope of spring-boot-dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,50 +37,25 @@
         <dependencies>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-logging</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-quartz</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-web</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-quartz</artifactId>
-                <version>${spring.boot.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-web</artifactId>
                 <version>${spring.boot.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-test</artifactId>
+                <version>${spring.boot.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-log4j2</artifactId>
                 <version>${spring.boot.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.data</groupId>
-                <artifactId>spring-data-mongodb</artifactId>
-                <version>${spring.mongodb.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>

--- a/swgoh-tracker-connector/pom.xml
+++ b/swgoh-tracker-connector/pom.xml
@@ -26,22 +26,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-dependencies</artifactId>
-            <version>${spring.boot.version}</version>
-            <type>pom</type>
-            <scope>import</scope> <!-- TODO must be one of [provided, compile, runtime, test, system] but is 'import' -->
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-quartz</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-mongodb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/swgoh-tracker-connector/src/test/java/com/amurgin/swgoh/tracker/SwgohApiCommonTests.java
+++ b/swgoh-tracker-connector/src/test/java/com/amurgin/swgoh/tracker/SwgohApiCommonTests.java
@@ -30,10 +30,9 @@ public class SwgohApiCommonTests {
   }
 
   @SneakyThrows
-  protected void getPlayerThrowsException(
-      Integer allyCode, Class<? extends Throwable> exceptionClass) {
+  protected void getPlayerThrowsException(Integer allyCode) {
     CompletableFuture<String> futureMock = Mockito.mock(CompletableFuture.class);
     Mockito.when(swgohApiConnector.getPlayer(allyCode)).thenReturn(futureMock);
-    Mockito.when(futureMock.get()).thenThrow(exceptionClass);
+    Mockito.when(futureMock.get()).thenThrow(java.util.concurrent.ExecutionException.class);
   }
 }

--- a/swgoh-tracker-connector/src/test/java/com/amurgin/swgoh/tracker/controller/AccountsControllerTest.java
+++ b/swgoh-tracker-connector/src/test/java/com/amurgin/swgoh/tracker/controller/AccountsControllerTest.java
@@ -9,7 +9,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.amurgin.swgoh.tracker.SwgohApiCommonTests;
 import com.amurgin.swgoh.tracker.configuration.SwgohAPIMockTestConfiguration;
 import com.amurgin.swgoh.tracker.configuration.SwgohApiDataPullServiceConfiguration;
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,7 +58,7 @@ public class AccountsControllerTest extends SwgohApiCommonTests {
   public void testFetchByAllyCode_unknownCode() throws Exception {
     // prepare
     var allyCode = 1;
-    getPlayerThrowsException(allyCode, ExecutionException.class);
+    getPlayerThrowsException(allyCode);
 
     mockMvc
         .perform(get("/accounts/" + 1))


### PR DESCRIPTION
### Goal
Fix a warning message in the Maven build log complaining on an inappropriate scope for spring-boot-dependencies: "must be one of [provided, compile, runtime, test, system] but is 'import'".

### Change Explanation:
- "import" scope of pom-dependency is applicable only for `<dependencyManagement>` section - this is a root cause of the warning.
- During investigation and testing of the fix, spring-boot-dependencies is deleted at all - only the required dependencies are left. Justification - let's avoid extra work for transitive dependencies management (faced problem with logging and quartz).
- Deleted mongodb dependency since it is not used by any code as of now.